### PR TITLE
Checkout Display Options

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -11,13 +11,14 @@ class Config
     /**
      * Config paths
      */
-    const XML_PATH_PAYMENT_CKGATEWAY     = 'payment/creditkey_gateway';
-    const XML_KEY_ENDPOINT               = '/creditkey_endpoint';
-    const XML_KEY_PUBLICKEY              = '/creditkey_publickey';
-    const XML_KEY_SECRET                 = '/creditkey_sharedsecret';
-    const XML_KEY_PDP_MARKETING_ACTIVE   = '/creditkey_productmarketing/active';
-    const XML_KEY_PDP_MARKETING_PRODUCTS = '/creditkey_productmarketing/products';
-    const XML_KEY_PDP_MARKETING_TYPE     = '/creditkey_productmarketing/type';
+    const XML_PATH_PAYMENT_CKGATEWAY      = 'payment/creditkey_gateway';
+    const XML_KEY_ENDPOINT                = '/creditkey_endpoint';
+    const XML_KEY_PUBLICKEY               = '/creditkey_publickey';
+    const XML_KEY_SECRET                  = '/creditkey_sharedsecret';
+    const XML_KEY_CHECKOUT_MARKETING_TYPE = '/creditkey_checkoutdisplay';
+    const XML_KEY_PDP_MARKETING_ACTIVE    = '/creditkey_productmarketing/active';
+    const XML_KEY_PDP_MARKETING_PRODUCTS  = '/creditkey_productmarketing/products';
+    const XML_KEY_PDP_MARKETING_TYPE      = '/creditkey_productmarketing/type';
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
@@ -88,6 +89,16 @@ class Config
     public function isPdpMarketingActive()
     {
         return (boolean) $this->getConfigValue(self::XML_KEY_PDP_MARKETING_ACTIVE);
+    }
+
+    /**
+     * Get the marketing display type for checkout
+     *
+     * @return string
+     */
+    public function getCheckoutMarketingType()
+    {
+        return $this->getConfigValue(self::XML_KEY_CHECKOUT_MARKETING_TYPE);
     }
 
     /**

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -104,7 +104,8 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
                     'assetSrc' => $this->assetRepo->getUrl("CreditKey_B2BGateway::images/ck-logo-new.svg"),
                     'redirectUrl' => $this->urlBuilder->getUrl('creditkey_gateway/order/create'),
                     'publicKey' => $this->config->getPublicKey(),
-                    'isCreditKeyDisplayed' => $isCreditKeyDisplayed
+                    'isCreditKeyDisplayed' => $isCreditKeyDisplayed,
+                    'type' => $this->config->getCheckoutMarketingType()
                 ]
             ]
         ];

--- a/README.md
+++ b/README.md
@@ -21,3 +21,20 @@ From the Magento admin, navigate to ```Stores > Configuration > Sales > Payment 
 If `title` is left blank the module will request the active promotion text from the Credit Key API.
 
 The `Marketing Content on Product Pages` section allows you to enable the Credit Key marketing content to be displayed on the selected product detail pages. You can enable/disable this feature globally, select the specific products to allow the content to be displayed on, and select the style of the displayed content.
+
+## Customization
+
+To move the location of the marketing display on the product details page you will need to modify the file `catalog_product_view.xml` from your active theme. This will most likely be located at `{magento_root}/app/design/frontend/{YourCompany}/{theme-name}/Magento_Catalog/layout/catalog_product_view.xml`. 
+
+In this file you would simply use the `<move>` element to move our block, named `product.info.creditkey.marketing`, to the new location. For example, if you wanted it to be just below the "Add to Cart" button it would look something like the following where `element` is the name of our block, `destination` is the name of the container you are moving it into, and `after` is the name of the block or container it will go after. This could instead be `before` if you want to place it before a specific block/container.
+
+    <?xml version="1.0"?>
+    <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+        <body>
+            <move element="product.info.creditkey.marketing" 
+                    destination="product.info.form.content" 
+                    after="product.info.addtocart"/>
+        </body>
+    </page>
+
+To see the available containers you can use reference Magento's primary `catalog_product_view.xml` file, located at `vendor/magento/module-catalog/view/frontend/layout/catalog_product_view.xml`.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -29,6 +29,11 @@
                   <label>Debug</label>
                   <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="creditkey_checkoutdisplay" translate="label comment" sortOrder="30" type="CreditKey\B2BGateway\Model\Form\Element\MarketingRadios" showInDefault="1" showInWebsite="1">
+                  <label>Checkout Display Type</label>
+                  <comment>Choose the style of the marketing content to display on checkout.</comment>
+                  <source_model>CreditKey\B2BGateway\Model\Adminhtml\Source\Buttons</source_model>
+                </field>
                 <group id="creditkey_productmarketing" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="200">
                   <label>Marketing Content on Product Pages</label>
                   <attribute type="expanded">1</attribute>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -23,6 +23,7 @@
                 <debugReplaceKeys>MERCHANT_KEY</debugReplaceKeys>
                 <paymentInfoKeys>FRAUD_MSG_LIST</paymentInfoKeys>
                 <privateInfoKeys>FRAUD_MSG_LIST</privateInfoKeys>
+                <creditkey_checkoutdisplay>text</creditkey_checkoutdisplay>
             </creditkey_gateway>
         </payment>
     </default>

--- a/view/adminhtml/web/js/config/creditkey_marketing.js
+++ b/view/adminhtml/web/js/config/creditkey_marketing.js
@@ -15,6 +15,7 @@ define([
 
         _init: function initMarketing() {
             var elem = this.element;
+            var view = ($(elem).attr('id').indexOf('checkout') > 0) ? 'checkout' : 'pdp';
             
             var ckClient = new creditKey.Client(
                 this.options.ckConfig.publicKey,
@@ -22,7 +23,7 @@ define([
             );
             var charges = new creditKey.Charges(0,0,0,0,0);
     
-            ckClient.get_marketing_display(charges, 'pdp', $(elem).val())
+            ckClient.get_marketing_display(charges, view, $(elem).val())
                 .then(function(res) {
                     $('label[for="' + $(elem).attr('id') + '"] span').html(res);
                 });

--- a/view/frontend/web/js/view/payment/method-renderer/creditkey_gateway.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditkey_gateway.js
@@ -65,9 +65,6 @@ define(
             
             isDisplayed: function() {
               var data = window.checkoutConfig.payment.creditkey_gateway;
-              if (data.isCreditKeyDisplayed) {
-                this.getCustomTitle();
-              }
               return data.isCreditKeyDisplayed;
             },
             

--- a/view/frontend/web/js/view/payment/method-renderer/creditkey_gateway.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditkey_gateway.js
@@ -69,12 +69,19 @@ define(
             },
             
             redirectToPayment: function() {
-              heap.track('Magento Redirect to Credit Key', { data: data.redirectUrl });
+              // validate the form
+              if (this.validate() && additionalValidators.validate()) {
+                // if valide then we call our checkout modal
+                heap.track('Magento Redirect to Credit Key', { data: data.redirectUrl });
               
-              setPaymentInformation(messageContainer, { method: quote.paymentMethod().method })
-                .then(function () {
-                  creditKey.checkout(data.redirectUrl, 'modal')
-                });
+                setPaymentInformation(messageContainer, { method: quote.paymentMethod().method })
+                  .then(function () {
+                    creditKey.checkout(data.redirectUrl, 'modal')
+                  });
+
+                return true;
+              }
+              return false;
             },
 
             redirectAfterPlaceOrder: false,

--- a/view/frontend/web/js/view/payment/method-renderer/creditkey_gateway.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditkey_gateway.js
@@ -57,7 +57,7 @@ define(
               // set a default display while loading
               $('#ck-payment-title').html('loading Credit Key...');
 
-              return ckClient.get_marketing_display(charges, "checkout", "text")
+              return ckClient.get_marketing_display(charges, "checkout", data.type)
                 .then(function(res) {
                   $('#ck-payment-title').html(res);
                 });

--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -14,7 +14,7 @@
                class="radio"
                data-bind="attr: {'id': getCode()}, value: getCode(), checked: isChecked, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
         <label class="label" data-bind="attr: {'for': getCode()}">
-          <span id="ck-payment-title"></span>
+          <span id="ck-payment-title" afterRender="getCustomTitle"></span>
         </label>
     </div>
 


### PR DESCRIPTION
The main purpose of this PR is to add the ability to choose the display type for the CreditKey payment method on checkout. It utillizes the same source model and component as the PDP display options and simply checks the field name to determine checkout vs pdp. These can be separated later if needed, but at this time they both seem to have the same options available.

This PR includes a few extra items as well

- The README has been updated with instructions for moving the PDP marketing content.
- The payment method renderer component has been updated to validate the checkout form before performing the redirect/modal action. This fixes the empty email error bug.
- The payment method renderer has been update to call the API to get the button on `afterRender` as opposed to when `isDisplayed` is called. I noticed that `isDisplayed` is called every time you select a payment method (assuming you have more than one available) so the API was called every time you switch between selected payment methods. The `afterRender` action only happens once, so this should improve the experience here.