### PR TITLE
Added Cancel command for Orders

### DIFF
--- a/Controller/Order/Complete.php
+++ b/Controller/Order/Complete.php
@@ -137,7 +137,12 @@ class Complete extends \CreditKey\B2BGateway\Controller\AbstractCreditKeyControl
             $orderPayment = $order->getPayment();
             $orderPayment->setAdditionalInformation('ckOrderId', $ckOrderId);
             $orderPayment->setTransactionId($ckOrderId);
-            $orderPayment->setState('paid');
+            $orderPayment->setLastTransId($ckOrderId);
+            $orderPayment->setIsTransactionClosed(false);
+            $orderPayment->setShouldCloseParentTransaction(false);
+            $transaction = $orderPayment->addTransaction(
+                \Magento\Sales\Model\Order\Payment\Transaction::TYPE_AUTH
+            );
 
             $order->save();
 
@@ -160,6 +165,7 @@ class Complete extends \CreditKey\B2BGateway\Controller\AbstractCreditKeyControl
 
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $resultRedirect->setPath('checkout/onepage/success');
+        $this->logger->debug('Finished order complete controller.');
         return $resultRedirect;
     }
 }

--- a/Gateway/Command/AuthorizeCommand.php
+++ b/Gateway/Command/AuthorizeCommand.php
@@ -40,8 +40,6 @@ class AuthorizeCommand implements CommandInterface
 
         $this->logger->debug('Authorizing Credit Key Payment: ' . $payment->getId());
 
-        $payment->setIsTransactionClosed(false);
-
         return null;
     }
 }

--- a/Gateway/Command/CancelCommand.php
+++ b/Gateway/Command/CancelCommand.php
@@ -1,0 +1,56 @@
+<?php
+namespace CreditKey\B2BGateway\Gateway\Command;
+
+use Magento\Payment\Gateway\Command;
+use Magento\Payment\Gateway\Command\CommandException;
+use Magento\Payment\Gateway\CommandInterface;
+
+/**
+ * Cancel Command
+ */
+class CancelCommand implements CommandInterface
+{
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \CreditKey\B2BGateway\Helper\Api
+     */
+    private $creditKeyApi;
+
+    /**
+     * Construct
+     *
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \CreditKey\B2BGateway\Helper\Api $creditKeyApi
+     */
+    public function __construct(
+        \Psr\Log\LoggerInterface $logger,
+        \CreditKey\B2BGateway\Helper\Api $creditKeyApi
+    ) {
+        $this->logger = $logger;
+        $this->creditKeyApi = $creditKeyApi;
+    }
+
+    /**
+     * Executes command basing on business object
+     *
+     * @param array $commandSubject
+     * @return null|Command\ResultInterface
+     * @throws CommandException
+     */
+    public function execute(array $commandSubject)
+    {
+        $paymentDO = $commandSubject['payment'];
+
+        $payment = $paymentDO->getPayment();
+        $ckOrderId = $payment->getAdditionalInformation('ckOrderId');
+
+        $this->creditKeyApi->configure();
+        $ckOrder = \CreditKey\Orders::cancel($ckOrderId);
+
+        return null;
+    }
+}

--- a/Gateway/Config/CanVoidHandler.php
+++ b/Gateway/Config/CanVoidHandler.php
@@ -1,0 +1,27 @@
+<?php
+namespace CreditKey\B2BGateway\Gateway\Config;
+
+use Magento\Payment\Gateway\Config\ValueHandlerInterface;
+use Magento\Sales\Model\Order\Payment;
+
+/**
+ * Can Void Handler
+ */
+class CanVoidHandler implements ValueHandlerInterface
+{
+    /**
+     * Retrieve method configured value
+     *
+     * @param array $subject
+     * @param int|null $storeId
+     *
+     * @return mixed
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function handle(array $subject, $storeId = null)
+    {
+        $paymentDO = $subject['payment'];
+        $payment = $paymentDO->getPayment();
+        return $payment instanceof Payment && !(bool)$payment->getAmountPaid();
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -34,6 +34,7 @@
                 <item name="authorize" xsi:type="string">CreditKey\B2BGateway\Gateway\Command\AuthorizeCommand</item>
                 <item name="capture" xsi:type="string">CreditKey\B2BGateway\Gateway\Command\CaptureCommand</item>
                 <item name="void" xsi:type="string">CreditKey\B2BGateway\Gateway\Command\VoidCommand</item>
+                <item name="cancel" xsi:type="string">CreditKey\B2BGateway\Gateway\Command\CancelCommand</item>
                 <item name="refund" xsi:type="string">CreditKey\B2BGateway\Gateway\Command\RefundCommand</item>
             </argument>
         </arguments>
@@ -44,6 +45,8 @@
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">CreditKeyB2BGatewayConfigValueHandler</item>
+                <item name="can_void" xsi:type="string">CreditKey\B2BGateway\Gateway\Config\CanVoidHandler</item>
+                <item name="can_cancel" xsi:type="string">CreditKey\B2BGateway\Gateway\Config\CanVoidHandler</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
This PR adds the functionality to call CreditKey's cancel command when the order is canceled. In order to do this we first had to make sure an authorization transaction was being created in Magento. Once that transaction existed then a cancel can happen which voids that transaction and calls our CancelCommand.