### PR TITLE
Whitelist checkout logo asset host

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -7,5 +7,10 @@
                 <value id="unpkg-cdn" type="host">unpkg.com</value>
             </values>
         </policy>
+        <policy id="img-src">
+            <values>
+                <value id="creditkey-assets-s3" type="host">creditkey-assets.s3-us-west-2.amazonaws.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>


### PR DESCRIPTION
## Summary
- Add the Credit Key S3 asset host to Magento CSP img-src whitelist
- Allows the checkout payment logo to load from creditkey-assets.s3-us-west-2.amazonaws.com

## Validation
- xmllint --noout etc/csp_whitelist.xml
- git diff --check