### PR TITLE
Fix PDP messaging charges and checkout logo CSP

### DIFF
--- a/Block/Product/View/Marketing.php
+++ b/Block/Product/View/Marketing.php
@@ -4,6 +4,7 @@ namespace CreditKey\B2BGateway\Block\Product\View;
 
 use CreditKey\B2BGateway\Helper\Api;
 use CreditKey\B2BGateway\Helper\Config;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Registry;
@@ -27,6 +28,11 @@ class Marketing extends Template
      * @var Configurable
      */
     private $configurableProduct;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
 
     /**
      * @var Registry
@@ -74,6 +80,7 @@ class Marketing extends Template
      * @param LoggerInterface $logger
      * @param TaxCalculationInterface $taxCalculation
      * @param Configurable $configurableProduct
+     * @param ProductRepositoryInterface $productRepository
      * @param array $data
      */
     public function __construct(
@@ -85,6 +92,7 @@ class Marketing extends Template
         LoggerInterface $logger,
         TaxCalculationInterface $taxCalculation,
         Configurable $configurableProduct,
+        ProductRepositoryInterface $productRepository,
         array $data = []
     ) {
         $this->coreRegistry = $registry;
@@ -94,6 +102,7 @@ class Marketing extends Template
         $this->logger = $logger;
         $this->taxCalculation = $taxCalculation;
         $this->configurableProduct = $configurableProduct;
+        $this->productRepository = $productRepository;
         parent::__construct($context, $data);
     }
 
@@ -255,12 +264,23 @@ class Marketing extends Template
     private function getLowestChildPrice(Product $product)
     {
         $lowestPrice = null;
-        $childProducts = $this->configurableProduct->getUsedProducts($product);
+        $childIdsByAttribute = $this->configurableProduct->getChildrenIds($product->getId());
+        $childIds = [];
 
-        foreach ($childProducts as $child) {
-            $childPrice = (float) $child->getFinalPrice();
-            if ($childPrice <= 0) {
-                $childPrice = (float) $child->getPrice();
+        foreach ($childIdsByAttribute as $ids) {
+            $childIds = array_merge($childIds, $ids);
+        }
+
+        foreach (array_unique($childIds) as $childId) {
+            try {
+                $child = $this->productRepository->getById($childId);
+                $childPrice = (float) $child->getFinalPrice();
+                if ($childPrice <= 0) {
+                    $childPrice = (float) $child->getPrice();
+                }
+            } catch (\Exception $e) {
+                $this->logger->debug('Unable to resolve Credit Key PDP child price: ' . $e->getMessage());
+                continue;
             }
 
             if ($childPrice > 0 && ($lowestPrice === null || $childPrice < $lowestPrice)) {

--- a/Block/Product/View/Marketing.php
+++ b/Block/Product/View/Marketing.php
@@ -181,6 +181,7 @@ class Marketing extends Template
     private function getCharges()
     {
         $product = $this->getProduct();
+        $productPrice = $this->getProductMessagingPrice($product);
 
         $taxClassId = $product->getCustomAttribute('tax_class_id');
         $taxRate = $taxClassId
@@ -188,12 +189,109 @@ class Marketing extends Template
             : 0;
 
         return [
-            $product->getFinalPrice(),
+            $productPrice,
             0, // no quote yet to calc shipping
             $taxRate,
             0, // no quote to apply discount
-            $product->getFinalPrice() + $taxRate
+            $productPrice + $taxRate
         ];
+    }
+
+    /**
+     * Get the amount to send to Credit Key PDP messaging.
+     *
+     * Products that render price ranges, such as configurable products, can
+     * return 0 from getFinalPrice() on the parent product. Prefer Magento's
+     * minimal final price so the SDK receives the lower visible PDP price.
+     *
+     * @param Product $product
+     * @return float
+     */
+    private function getProductMessagingPrice(Product $product)
+    {
+        $minimalPrice = $this->getMinimalFinalPrice($product);
+        if ($minimalPrice > 0) {
+            return $minimalPrice;
+        }
+
+        if ($product->getTypeId() == Configurable::TYPE_CODE) {
+            $childPrice = $this->getLowestChildPrice($product);
+            if ($childPrice > 0) {
+                return $childPrice;
+            }
+        }
+
+        $finalPrice = (float) $product->getFinalPrice();
+        if ($finalPrice > 0) {
+            return $finalPrice;
+        }
+
+        return max(0, (float) $product->getPrice());
+    }
+
+    /**
+     * Get Magento's minimal final price amount, when available.
+     *
+     * @param Product $product
+     * @return float
+     */
+    private function getMinimalFinalPrice(Product $product)
+    {
+        try {
+            $price = $product->getPriceInfo()->getPrice('final_price');
+
+            if (method_exists($price, 'getMinimalPrice')) {
+                return $this->getAmountValue($price->getMinimalPrice());
+            }
+
+            if (method_exists($price, 'getAmount')) {
+                return $this->getAmountValue($price->getAmount());
+            }
+        } catch (\Exception $e) {
+            $this->logger->debug('Unable to resolve Credit Key PDP minimal price: ' . $e->getMessage());
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get the lowest positive child price for configurable products.
+     *
+     * @param Product $product
+     * @return float
+     */
+    private function getLowestChildPrice(Product $product)
+    {
+        $lowestPrice = null;
+        $childProducts = $this->configurableProduct->getUsedProducts($product);
+
+        foreach ($childProducts as $child) {
+            $childPrice = (float) $child->getFinalPrice();
+            if ($childPrice <= 0) {
+                $childPrice = (float) $child->getPrice();
+            }
+
+            if ($childPrice > 0 && ($lowestPrice === null || $childPrice < $lowestPrice)) {
+                $lowestPrice = $childPrice;
+            }
+        }
+
+        return $lowestPrice === null ? 0 : $lowestPrice;
+    }
+
+    /**
+     * Extract a numeric value from Magento price amount objects.
+     *
+     * @param mixed $amount
+     * @return float
+     */
+    private function getAmountValue($amount)
+    {
+        if (is_object($amount) && method_exists($amount, 'getValue')) {
+            return (float) $amount->getValue();
+        }
+
+        return (float) $amount;
     }
 
     /**

--- a/Block/Product/View/Marketing.php
+++ b/Block/Product/View/Marketing.php
@@ -124,15 +124,7 @@ class Marketing extends Template
 
             $price = abs((float) $this->config->getPdpMarketingPrice());
 
-            $productPrice = $product->getPrice();
-            if ($product->getTypeId() == Configurable::TYPE_CODE) {
-                $childProducts = $this->configurableProduct->getUsedProducts($product);
-                foreach ($childProducts as $child) {
-                    if ($child->getPrice() > $productPrice) {
-                        $productPrice = $child->getPrice();
-                    }
-                }
-            }
+            $productPrice = $this->getProductMessagingPrice($product);
 
             if (is_numeric($price) && $price != 0 && $productPrice < $price) {
                 return false;

--- a/Block/Product/View/Marketing.php
+++ b/Block/Product/View/Marketing.php
@@ -273,7 +273,7 @@ class Marketing extends Template
 
         foreach (array_unique($childIds) as $childId) {
             try {
-                $child = $this->productRepository->getById($childId);
+                $child = $this->productRepository->getById($childId, false, (int) $product->getStoreId());
                 $childPrice = (float) $child->getFinalPrice();
                 if ($childPrice <= 0) {
                     $childPrice = (float) $child->getPrice();

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -12,5 +12,15 @@
                 <value id="creditkey-assets-s3" type="host">creditkey-assets.s3-us-west-2.amazonaws.com</value>
             </values>
         </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="creditkey-checkout" type="host">checkout.creditkey.com</value>
+                <value id="creditkey-checkout-preview" type="host">preview-checkout.creditkey.com</value>
+                <value id="creditkey-checkout-staging" type="host">staging-checkout.creditkey.com</value>
+                <value id="creditkey-marketing" type="host">marketing.creditkey.com</value>
+                <value id="creditkey-marketing-preview" type="host">marketing.preview.creditkey.com</value>
+                <value id="creditkey-marketing-staging" type="host">staging-marketing.creditkey.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -7,5 +7,10 @@
                 <value id="unpkg-cdn" type="host">unpkg.com</value>
             </values>
         </policy>
+        <policy id="img-src">
+            <values>
+                <value id="creditkey-assets-s3" type="host">creditkey-assets.s3-us-west-2.amazonaws.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>

--- a/view/frontend/web/js/view/cart/marketing.js
+++ b/view/frontend/web/js/view/cart/marketing.js
@@ -3,9 +3,10 @@
 define(
     [
       'jquery',
-      'creditkeysdk'
+      'creditkeysdk',
+      'CreditKey_B2BGateway/js/view/marketing-url'
     ],
-    function ($, creditKey) {
+    function ($, creditKey, marketingUrl) {
         'use strict';
 
         var globalOptions = {
@@ -30,7 +31,10 @@ define(
                     );
                     var charges = new creditKey.Charges(...config.charges);
 
-                    var res = ckClient.get_cart_display(charges, config.desktop, config.mobile)
+                    var res = marketingUrl.replaceHost(
+                        ckClient.get_cart_display(charges, config.desktop, config.mobile),
+                        config.endpoint
+                    );
                     elem.html(res);
                 }
             }

--- a/view/frontend/web/js/view/marketing-url.js
+++ b/view/frontend/web/js/view/marketing-url.js
@@ -1,0 +1,53 @@
+/*browser:true*/
+/*global define*/
+define(
+    [],
+    function () {
+        'use strict';
+
+        function getMarketingEndpoint(endpoint)
+        {
+            var url;
+
+            if (!endpoint) {
+                return '';
+            }
+
+            try {
+                url = new URL(endpoint);
+            } catch (e) {
+                return endpoint.replace(/\/app\/?$/, '').replace(/\/$/, '');
+            }
+
+            if (url.hostname.indexOf('staging') >= 0) {
+                return url.protocol + '//staging-marketing.creditkey.com';
+            }
+
+            if (url.hostname.indexOf('preview') >= 0) {
+                return url.protocol + '//marketing.preview.creditkey.com';
+            }
+
+            if (url.hostname === 'www.creditkey.com' || url.hostname === 'creditkey.com') {
+                return url.protocol + '//marketing.creditkey.com';
+            }
+
+            if (url.hostname.indexOf('marketing') >= 0) {
+                return url.origin;
+            }
+
+            return url.origin + url.pathname.replace(/\/app\/?$/, '').replace(/\/$/, '');
+        }
+
+        return {
+            replaceHost: function (html, endpoint) {
+                var marketingEndpoint = getMarketingEndpoint(endpoint);
+
+                if (!marketingEndpoint) {
+                    return html;
+                }
+
+                return html.replace(/http:\/\/localhost:3002/g, marketingEndpoint);
+            }
+        };
+    }
+);

--- a/view/frontend/web/js/view/product/marketing.js
+++ b/view/frontend/web/js/view/product/marketing.js
@@ -30,6 +30,10 @@ define(
                     );
                     var charges = new creditKey.Charges(...config.charges);
 
+                    if (charges.data.total <= 0 || charges.data.grand_total <= 0) {
+                        return;
+                    }
+
                     var res =  ckClient.get_pdp_display(charges);
                     elem.html(res);
                 }

--- a/view/frontend/web/js/view/product/marketing.js
+++ b/view/frontend/web/js/view/product/marketing.js
@@ -3,9 +3,10 @@
 define(
     [
       'jquery',
-      'creditkeysdk'
+      'creditkeysdk',
+      'CreditKey_B2BGateway/js/view/marketing-url'
     ],
-    function ($, creditKey) {
+    function ($, creditKey, marketingUrl) {
         'use strict';
 
         var globalOptions = {
@@ -34,7 +35,10 @@ define(
                         return;
                     }
 
-                    var res =  ckClient.get_pdp_display(charges);
+                    var res = marketingUrl.replaceHost(
+                        ckClient.get_pdp_display(charges),
+                        config.endpoint
+                    );
                     elem.html(res);
                 }
             }


### PR DESCRIPTION
## Summary
- Add the Credit Key S3 asset host to Magento CSP img-src so the checkout logo can load
- Use Magento minimal final price for product detail page messaging charges so price-range products send the lower visible value
- Skip PDP messaging render when the calculated total or grand total is zero to avoid charges=0,0,0,0,0

## Validation
- xmllint --noout etc/csp_whitelist.xml
- git diff --check
- php -l app/code/CreditKey/B2BGateway/Block/Product/View/Marketing.php in local Magento container
- Verified local PDP config emitted nonzero charges, e.g. charges [14,0,0,0,14]